### PR TITLE
Fix typo in fundamentals/object docs

### DIFF
--- a/fundamentals/object/README.md
+++ b/fundamentals/object/README.md
@@ -10,7 +10,7 @@ People, Books, Musicians, Documents, Ideas, Places, Numbers, or Files. In Anytyp
 
 ### Object Canvas
 
-Every object has a flexible editing area that we call the "canvas". The canvas contains "blocks", each of which is a piece of information that you can freely move around the canvas. Blocks can take many forms and enable a wide variety of functionality and design adjustments, including text color and highlighting, alignment, and more. You can add a new blocks to hold any information you like by hitting the `+` button or do so in-line by typing `/`. However over a block to see its size or move it elsewhere on the canvas. To create a column, drag one block alongside another block.
+Every object has a flexible editing area that we call the "canvas". The canvas contains "blocks", each of which is a piece of information that you can freely move around the canvas. Blocks can take many forms and enable a wide variety of functionality and design adjustments, including text color and highlighting, alignment, and more. You can add a new blocks to hold any information you like by hitting the `+` button or do so in-line by typing `/`. Hover over a block to see its size or move it elsewhere on the canvas. To create a column, drag one block alongside another block.
 
 {% hint style="info" %}
 Check out [blocks-and-canvas](blocks-and-canvas/ "mention")for more details


### PR DESCRIPTION
I believe the sentence is supposed to read `Hover over a block to see its size or move it elsewhere on the canvas.`, but currently it says `However over a block to see its size or move it elsewhere on the canvas.`.

I apologize if this is not the appropriate way to suggest changes, I just noticed this type and figured I would submit a pull request in case it was helpful. Thanks to the Anytype team for this excellent tool!