### PR TITLE
Fix typo and format

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Your data is E2E encrypted from the moment it leaves your device. As a participa
 \
 We cannot however, understand anything about your data even if we look at it on our backup node - not what type of object it is, what is contained within it, nor which Objects it is linked to. It is only possible to see that X user has a tree of encrypted messages connected with each other via IDs.\
 \
-To understand more about how data is treated in the alpha program, please have a look at [this page in our docs](https://doc.anytype.io/d/features/privacy-and-security).
+To understand more about how data is treated in the alpha program, please have a look at [Privacy & Security](https://doc.anytype.io/d/features/privacy-and-security).
 
 ### Community-first: Build Anytype Together with Us 💚&#x20;
 

--- a/faqs/free-forever-how-will-anytype-make-money.md
+++ b/faqs/free-forever-how-will-anytype-make-money.md
@@ -9,5 +9,5 @@ Initially, we will offer subscriptions for decentralized backup services to our 
 You can use Anytype for free anytime without any storage or upload limits because you’re using the disk space on your devices. Some users may also want to ensure their data is backed up, and we will offer them a place on decentralized Anytype nodes. The stored information is encrypted, and we have neither access to the user’s data nor their encryption keys.
 
 {% hint style="success" %}
-For Alpha testers, backup storage will be offered for free as a gift
+For Alpha testers, backup storage will be offered for free as a gift.
 {% endhint %}

--- a/faqs/how-are-media-files-stored-on-devices.md
+++ b/faqs/how-are-media-files-stored-on-devices.md
@@ -7,7 +7,7 @@ To keep bandwidth and storage usage low but provide a fast experience, Anytype d
 **Files** are fully downloaded when you press download and get "cached" on your device.
 
 {% hint style="info" %}
-Working with cache is not yet available and will be implemented in the next release
+Working with cache is not yet available and will be implemented in the next release.
 {% endhint %}
 
 {% content-ref url="storage-and-deletion.md" %}

--- a/faqs/privacy-and-security.md
+++ b/faqs/privacy-and-security.md
@@ -26,7 +26,7 @@ There are some technical details on encryption and data storage:
 
 * Anytype stores changes for each object you’ve created
 * Every object’s change has 2 encryption layers with different keys.&#x20;
-* the First layer is used to connect changes within an object (e.g. all this encrypted data belongs to the object with id \<abc>)
+* The First layer is used to connect changes within an object (for example, all this encrypted data belongs to the object with id \<abc>)
 * Second layer is used to encrypt the actual data. We using AES with stream **encryption** with CFB mode
 * When you create a new change for an object, we periodically send it to our backup node(with only the first-layer key). More info about sync [here](syncing-and-p2p.md).
 * Anytype backup nodes have access to the first layer key, so it can group changes for the object and send them in one pack when you want to restore your data

--- a/faqs/storage-and-deletion.md
+++ b/faqs/storage-and-deletion.md
@@ -4,15 +4,15 @@
 
 Anytype is Offline first; hence, all data you create will be stored locally first. After that, the data is synced to the backup node and your devices for redundancy.
 
-We use a private IPFS network and [ThreadDB](https://docs.textile.io/threads/) to handle storage. It is a Peer-To-Peer file system that facilitates decentralized data storage across devices. Furthermore, we use the deduplication feature to reduce storage. E.g. If the same picture is uploaded three times, there is only one image copy stored to reduce storage consumption.
+We use a private IPFS network and [ThreadDB](https://docs.textile.io/threads/) to handle storage. It is a Peer-To-Peer file system that facilitates decentralized data storage across devices. Furthermore, we use the deduplication feature to reduce storage. For example, if the same picture is uploaded three times, there is only one image copy stored to reduce storage consumption.
 
 {% hint style="info" %}
-You can read more about IPFS here: [we-are-using-ipfs.-what-is-that.md](../faqs/we-are-using-ipfs.-what-is-that.md "mention")
+You can read more about IPFS here: [we-are-using-ipfs.-what-is-that.md](../faqs/we-are-using-ipfs.-what-is-that.md "mention").
 {% endhint %}
 
 ### Media
 
-Media files are not directly downloaded in overall syncing to save bandwidth. Instead, when that file is requested, it is streamed to your device from the backup node or your devices on the network. E.g. If you have a 4k Video, it will be streamed from the backup node or P2P devices to your device.
+Media files are not directly downloaded in overall syncing to save bandwidth. Instead, when that file is requested, it is streamed to your device from the backup node or your devices on the network. For example, if you have a 4K Video, it will be streamed from the backup node or P2P devices to your device.
 
 So when you open an object with an image, it downloads. When you press play on video & audio, it begins to download. After that, this file will be stored in the application cache.
 
@@ -43,5 +43,5 @@ The Anytype Root Folder is a variable based on the OS where all your local data 
 Anytype does not have a way to reference files from the OS files system. So all the files are getting copied when you drop media and files inside Anytype. We will introduce this feature later.
 
 {% hint style="success" %}
-By the way, you can check our roadmap in the [Community Forum](https://community.anytype.io/t/release-plan-a-general-roadmap/1283)
+By the way, you can check our roadmap in the [Community Forum](https://community.anytype.io/t/release-plan-a-general-roadmap/1283).
 {% endhint %}

--- a/fundamental-concepts.md
+++ b/fundamental-concepts.md
@@ -20,7 +20,7 @@ People, Books, Musicians, Documents, Ideas, Places, Numbers, or Files. In Anytyp
 
 ### Every Object has a Type
 
-While everything is an Object, it helps to differentiate or group these Objects so that we can  draw meaningful distinctions between them. That's where **Types** come in.&#x20;
+While everything is an Object, it helps to differentiate or group these Objects so that we can draw meaningful distinctions between them. That's where **Types** come in.&#x20;
 
 In the above schema, Berlin has the Type: Location, and _2001: A Space Odyssey_ has the Type: Movie - not so different from how we think of 'objects' in the real world. Berlin and _Space Odyssey_ occupy very different spaces in my mind (even though they are both 'Objects' in my Anyverse), because they have different characteristics that make them almost incomparable. One is a city, meanwhile the other is a film.
 
@@ -30,7 +30,7 @@ For this reason, each Object you create in Anytype has a Type, which is always v
 
 When considering all of the Objects in your life (humans, ideas, tasks, projects), you most likely do not envision them as independent modules, but rather as an interconnected web with unique relationships that link them together.&#x20;
 
-**Relations** are a tool to help you define the connections that exist between Objects. For example, I have two Objects in my graph: A Book (_Sapiens_) and a Human (Yuval Noah Harari).  These two are connected by the Relation: Author. Yuval Noah Harari is the **author** of _Sapiens_. \
+**Relations** are a tool to help you define the connections that exist between Objects. For example, I have two Objects in my graph: A Book (_Sapiens_) and a Human (Yuval Noah Harari). These two are connected by the Relation: Author. Yuval Noah Harari is the **author** of _Sapiens_. \
 \
 Now that the Relation between these two Objects has been defined, they are no longer independent entities in my knowledge graph. The more Relations I've created between Objects, the better I'm able to visualize how they are connected.
 
@@ -45,8 +45,6 @@ Read on for a deep dive into Relations and how they work in Practice:
 Sets don't store objects like regular databases. Instead, they are a way to see a portion of your knowledge graph that matches the given criteria, for instance: Objects with Type: Task. Once I create a Set with this criteria, any Task Object I've created will be visible to me in a single view.&#x20;
 
 Read on for a deep dive into Sets and how to use them:
-
-
 
 {% hint style="info" %}
 Primary and Profile layouts support either an emoji or a photo icon. All layouts, except Note, support a cover image.

--- a/how-to/navigation.md
+++ b/how-to/navigation.md
@@ -12,7 +12,7 @@ For navigation inside Anytype, you have 4 options: **`Home, Search, Graph View`,
 
 ![Adding object to Favorites](../.gitbook/assets/ezgif-2-b73c8e1a497a.gif)
 
-* **History**. has objects that were opened recently
+* **History** has objects that were opened recently
 * **Sets** that you have ever created.
 * **Bin** has recently deleted objects. You can put it back or delete it irrevocably.
 

--- a/migrating/start/fundamentaldifferences.md
+++ b/migrating/start/fundamentaldifferences.md
@@ -33,7 +33,7 @@ Click on the block dragger to see options available for a block, such as deletio
 ![The drop-down menu which appears upon clicking the pill dragger.](../../.gitbook/assets/blockoptions.png)
 
 {% hint style="info" %}
-To see a list of all available blocks, please check [Anytype-editor](../../self-onboarding/Anytype-editor/ "mention")
+To see a list of all available blocks, please check [Anytype-editor](../../self-onboarding/Anytype-editor/ "mention").
 {% endhint %}
 
 ### Moving Blocks
@@ -79,7 +79,7 @@ Anytype's of object linking architecture are more flexible than Notion. You may 
 Having objects (or pages, if that's what you prefer) not be locked inside a hierarchical silo but instead linked together in a knowledge graph brings numerous advantages. You no longer need to think about \*where\* an object belongs in your tree or where to place it. You simply link it. This allows for a much more natural flow of information than storing data inside a hierarchical note system.
 
 {% hint style="info" %}
-If you want to read further about the advantages and disadvantages a non-hierarchical architecture brings to Anytype, [author](https://github.com/jonathan2384) highly recommends reading this article: [https://www.nayuki.io/page/designing-better-file-organization-around-tags-not-hierarchies](https://www.nayuki.io/page/designing-better-file-organization-around-tags-not-hierarchies)
+If you want to read further about the advantages and disadvantages a non-hierarchical architecture brings to Anytype, [author](https://github.com/jonathan2384) highly recommends reading this article: [https://www.nayuki.io/page/designing-better-file-organization-around-tags-not-hierarchies](https://www.nayuki.io/page/designing-better-file-organization-around-tags-not-hierarchies).
 {% endhint %}
 
 ## Databases
@@ -94,7 +94,7 @@ Anytype's equivalent to Notion's databases are Sets. However, unlike Notion data
 
 This makes Anytype much more flexible than Notion. For example, if you wanted to create a database with Notion, you are stuck with it. You cannot move pages outside of the database, nor can you bring pages inside a database once they have already been created (without annoying workarounds and time-wasting steps.) Instead, with Anytype, you can get **any** existing object in view with a Set.
 
-![Here's an Anytype set. Right now, it's configured to show all Objects with the  Task](../../.gitbook/assets/setexample.png)
+![Here's an Anytype set. Right now, it's configured to show all Objects with the Task](../../.gitbook/assets/setexample.png)
 
 Have trouble understanding Anytype's databases?
 
@@ -102,7 +102,7 @@ Have trouble understanding Anytype's databases?
 * <mark style="background-color:yellow;">To create a "database" in Anytype, first, create a Type, then create a new Set to show all objects of that Type.</mark>
 
 {% hint style="info" %}
-Learn more about this theme here: [Broken link](broken-reference "mention") and [set.md](../../self-onboarding/set.md "mention")
+Learn more about this theme here: [Broken link](broken-reference "mention") and [set.md](../../self-onboarding/set.md "mention").
 {% endhint %}
 
 ### Relations

--- a/use-cases-and-tutorials/creating-a-place-for-studies.md
+++ b/use-cases-and-tutorials/creating-a-place-for-studies.md
@@ -30,5 +30,5 @@ It is handy to create Templates. While creating notes in class or meetings, you 
 ![Class Note template](<../.gitbook/assets/Screenshot 2021-11-11 at 11.52.51 (1).png>)
 
 {% hint style="success" %}
-Find ideas to spark inspiration in [Community Showcases](https://community.anytype.io/c/general-discussion/showcase/13)
+Find ideas to spark inspiration in [Community Showcases](https://community.anytype.io/c/general-discussion/showcase/13).
 {% endhint %}

--- a/use-cases-and-tutorials/creating-a-reading-list.md
+++ b/use-cases-and-tutorials/creating-a-reading-list.md
@@ -23,7 +23,7 @@ If you want to create a more broad Reading List with several entities inside lik
 
 ### Template
 
-It is convenient to create templates for each view and object type. E.g. a template for Books will have `Author, Rating, Pages` etc. Whereas a template for Blog posts or Articles will have the `URL, Topic` and other additional information. Using templates with multiple views and filters is the fastest way to add new information without opening pages.
+It is convenient to create templates for each view and object type. For example, a template for Books includes `Author`, `Rating`, and`Pages`. Whereas a template for Blog posts or Articles includes the `URL`, `Topic` and other additional information. Using templates with multiple views and filters is the fastest way to add new information without opening pages.
 
 {% hint style="success" %}
 ​Find ideas to spark inspiration in [Community Showcases](https://community.anytype.io/c/general-discussion/showcase/13)

--- a/use-cases-and-tutorials/creating-a-reading-list.md
+++ b/use-cases-and-tutorials/creating-a-reading-list.md
@@ -26,5 +26,5 @@ If you want to create a more broad Reading List with several entities inside lik
 It is convenient to create templates for each view and object type. For example, a template for Books includes `Author`, `Rating`, and`Pages`. Whereas a template for Blog posts or Articles includes the `URL`, `Topic` and other additional information. Using templates with multiple views and filters is the fastest way to add new information without opening pages.
 
 {% hint style="success" %}
-​Find ideas to spark inspiration in [Community Showcases](https://community.anytype.io/c/general-discussion/showcase/13)
+​Find ideas to spark inspiration in [Community Showcases](https://community.anytype.io/c/general-discussion/showcase/13).
 {% endhint %}

--- a/use-cases-and-tutorials/creating-a-task-tracker.md
+++ b/use-cases-and-tutorials/creating-a-task-tracker.md
@@ -5,7 +5,7 @@
 ### Steps
 
 1. To create a **Task tracker**, you need to click + on home, choose [set.md](../self-onboarding/set.md "mention") and set **Task** as a source. That's it. You just started a task tracker!
-2. So now you can view all Tasks in one place. For the Task list, you may add relations. `Tag`, `Due date`, `Priority`, Or any other use for your tracker.
+2. So now you can view all Tasks in one place. For the Task list, you may add relations. `Tag`, `Due date`, `Priority`, or any other use for your tracker.
 3. You can also use filters, sorts, and views like:
    1. Relation `Done` `Is` `Unchecked` so you will see only those that are not done
    2. Create a view Work and Personal with filters `Tag` `contains` `Work` and `Tag` `contains` `Personal` to separate the lists
@@ -35,5 +35,5 @@ It's convenient to create templates for repeatable tasks with pre-filled options
 ![](../.gitbook/assets/1631701898-853229-screenshot-2021-09-15-at-133017.png)
 
 {% hint style="success" %}
-Find ideas to spark <mark style="background-color:purple;">inspiration</mark> in [Community Showcases](https://community.anytype.io/c/general-discussion/showcase/13)
+Find ideas to spark <mark style="background-color:purple;">inspiration</mark> in [Community Showcases](https://community.anytype.io/c/general-discussion/showcase/13).
 {% endhint %}

--- a/use-cases-and-tutorials/organizing-notes/capture-simple-notes.md
+++ b/use-cases-and-tutorials/organizing-notes/capture-simple-notes.md
@@ -14,7 +14,7 @@ You can create Notes everywhere you want. Every object you create by default is 
 Sets collect all objects by given criteria. For example, if you add a new Note anywhere inside the Anytype, it will be shown here! By default, it is sorted by creation date.
 
 {% hint style="info" %}
-Click on links to know more about [Broken link](broken-reference "mention"), [set.md](../../self-onboarding/set.md "mention") & [relation.md](../../self-onboarding/relation.md "mention")
+Click on links to know more about [Broken link](broken-reference "mention"), [set.md](../../self-onboarding/set.md "mention") & [relation.md](../../self-onboarding/relation.md "mention").
 {% endhint %}
 
 ### Sort them later
@@ -40,5 +40,5 @@ Make these steps and start your Tags management:
    ![](<../../.gitbook/assets/image (3).png>) ![](<../../.gitbook/assets/image (4).png>)
 
 {% hint style="success" %}
-You can work with relations everywhere! Check out where and how you can also use Tags: [#adding-relations](../../self-onboarding/relation.md#adding-relations "mention")
+You can work with relations everywhere! Check out where and how you can also use Tags: [#adding-relations](../../self-onboarding/relation.md#adding-relations "mention").
 {% endhint %}

--- a/use-cases-and-tutorials/organizing-notes/outline-note-taking-method.md
+++ b/use-cases-and-tutorials/organizing-notes/outline-note-taking-method.md
@@ -7,7 +7,7 @@ The Outline method is one of college students' most popular note-taking methods.
 The next few steps will explain step by step how to organize your Anytype notes using the Outline method by creating a new Object type, template, and set.
 
 {% hint style="info" %}
-The outlining method emphasizes content as well as relationships between the material. It reduces the time needed for editing and allows for easy reviewing. [Click here for more information](https://e-student.org/outline-note-taking-method/)
+The outlining method emphasizes content as well as relationships between the material. It reduces the time needed for editing and allows for easy reviewing. [Click here for more information](https://e-student.org/outline-note-taking-method/).
 {% endhint %}
 
 ### Add Outline Note type
@@ -39,7 +39,7 @@ You need to create a new Set from the Home screen. Sets collect all objects by g
 ​​![](https://files.gitbook.com/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FMBWIxXziUmcK7h7uvLnI%2Fuploads%2FKMPQdN9bbOHenKcS7RtM%2Fset\_1.png?alt=media\&token=ffb09aa2-3fd9-496d-81bc-f6fbd571ed07)​ ![](../../.gitbook/assets/2\_outline\_set.png)​
 
 {% hint style="info" %}
-Sets help you sort through and create specific database-like views to work with many objects at once. Read how [#sets-and-relations](../../migrating/start/fundamentaldifferences.md#sets-and-relations "mention") perform in comparison to Notion Databases
+Sets help you sort through and create specific database-like views to work with many objects at once. Read how [#sets-and-relations](../../migrating/start/fundamentaldifferences.md#sets-and-relations "mention") perform in comparison to Notion Databases.
 {% endhint %}
 
 ### Customize your workflow <a href="#quickly-create-notes-by-adding-templates" id="quickly-create-notes-by-adding-templates"></a>
@@ -48,7 +48,7 @@ All the Outline Notes will be collected in the set. So you can create a flow to 
 
 1. Add "Reflection" relation and "Tag" to the Set. Create a view calling "Inbox"\
    ![](../../.gitbook/assets/2\_custom\_relations.png) ![](../../.gitbook/assets/2\_add\_view.png)
-2.  Add filter "Reflection" is unchecked. You can also add filter by Creation Date, so you will see only newly created. You can review all your Outline Method notes in one place
+2. Add filter "Reflection" is unchecked. You can also add filter by Creation Date, so you will see only newly created. You can review all your Outline Method notes in one place
 
     <img src="../../.gitbook/assets/2_add_filter.png" alt="" data-size="original"><img src="../../.gitbook/assets/2_finished.png" alt="" data-size="original">
 


### PR DESCRIPTION
Hi, Anytype maintainers 👋🏼 

I modified some docs as follows: 

- Remove duplicate white spaces
- Add a `.` at the end of each hint
- Use the title of the page as a link text instead of "this page"
- According to Google developer documentation style guide, use "for example" is much better than `e.g.`