### PR TITLE
Fix broken link

### DIFF
--- a/use-cases-and-tutorials/creating-a-task-tracker.md
+++ b/use-cases-and-tutorials/creating-a-task-tracker.md
@@ -21,7 +21,7 @@ Sets collect all your objects that match the given criterion. You can add a new 
 
 ### Custom type
 
-If you don't like **Relations** and **Templates** used in Task, you can [Broken link](broken-reference "mention") that will fit your needs.
+If you don't like **Relations** and **Templates** used in Task, you can [library.md](../how-to/library.md "mention") that will fit your needs.
 
 1. You need to open [library.md](../how-to/library.md "mention") in **Home** screen, which contains all **Types** in Anytype
 2. Press "Create a new type."


### PR DESCRIPTION
Not sure how you've got this set up to work in deployment but this should fix the broken link and read "create new Types" on the website. Might be worth changing it from library.md to something like create-new-types.md to make this more legible here on github.